### PR TITLE
Some suggestions

### DIFF
--- a/tiny/include/tiny/Parser.h
+++ b/tiny/include/tiny/Parser.h
@@ -70,7 +70,7 @@ private:
   Lexer &lexer;
 
   /// Parse a return statement.
-  /// return :== return ; | return expr ;
+  /// return ::= return | return expr
   std::unique_ptr<ReturnExprAST> parseReturn() {
     auto loc = lexer.getLastLocation();
     lexer.consume(tok_return);
@@ -433,7 +433,7 @@ private:
   }
 
 
-  // Parse a variable declaration, 
+  // Parse a variable declaration,
   // 1. it starts with a `var` keyword, followed by a variable name and initialization
   // 2. Two methods of initialization have been supported:
   //    (1) var a = [[1, 2, 3], [4, 5, 6]];
@@ -444,27 +444,26 @@ private:
   std::unique_ptr<VarDeclExprAST>
   parseVarDeclaration(bool requiresInitializer) {
 
-    // TODO: check to see if this is a 'var' declaration 
-    //       If not, report the error with 'parseError', otherwise eat 'var'  
-    /* 
+    // TODO: check to see if this is a 'var' declaration
+    //       If not, report the error with 'parseError', otherwise eat 'var'
+    /*
      *
      *  Write your code here.
      *
      */
 
-    // TODO: check to see if this is a variable name 
+    // TODO: check to see if this is a variable name
     //       If not, report the error with 'parseError'
-    /* 
+    /*
      *
      *  Write your code here.
      *
      */
-    // eat the variable name
     std::string id(lexer.getId());
-    lexer.getNextToken(); // eat id
+    lexer.getNextToken(); // eat the variable name
 
-    std::unique_ptr<VarType> type; 
-    // TODO: modify code to additionally support the third method: var a[][] = ... 
+    std::unique_ptr<VarType> type;
+    // TODO: modify code to additionally support the third method: var a[][] = ...
     if (lexer.getCurToken() == '<') {
       type = parseType();
       if (!type)
@@ -487,7 +486,7 @@ private:
   ///
   /// block ::= { expression_list }
   /// expression_list ::= block_expr ; expression_list
-  /// block_expr ::= decl | "return" | expr
+  /// block_expr ::= decl | return | expr
   std::unique_ptr<ExprASTList> parseBlock() {
     if (lexer.getCurToken() != '{')
       return parseError<ExprASTList>("{", "to begin block");

--- a/tiny/mlir/LowerToAffineLoops.cpp
+++ b/tiny/mlir/LowerToAffineLoops.cpp
@@ -216,7 +216,7 @@ struct FuncOpLowering : public OpConversionPattern<tiny::FuncOp> {
     }
 
     // Create a new non-tiny function, with the same region.
-    auto func = rewriter.create<mlir::FuncOp>(op.getLoc(), op.getName(),
+    auto func = rewriter.create<mlir::func::FuncOp>(op.getLoc(), op.getName(),
                                               op.getFunctionType());
     rewriter.inlineRegionBefore(op.getRegion(), func.getBody(), func.end());
     rewriter.eraseOp(op);

--- a/tiny/tinyc.cpp
+++ b/tiny/tinyc.cpp
@@ -153,7 +153,7 @@ int loadAndProcessMLIR(mlir::MLIRContext &context,
     pm.addPass(mlir::tiny::createLowerToAffinePass());
 
     // Add a few cleanups post lowering.
-    mlir::OpPassManager &optPM = pm.nest<mlir::FuncOp>();
+    mlir::OpPassManager &optPM = pm.nest<mlir::func::FuncOp>();
     optPM.addPass(mlir::createCanonicalizerPass());
     optPM.addPass(mlir::createCSEPass());
 


### PR DESCRIPTION
(在做作业的时候碰到几点问题，觉得有一部分可能会对同学带来困扰，所以发个 PR)

1. 将框架中的 `mlir::FuncOp` 修改为 `milr::func::FuncOp` 。我本地编译时出现了报错 `error: no member named 'FuncOp' in namespace 'mlir'` ，查找后发现在[今年 3.17 的 commit 3655069](https://github.com/llvm/llvm-project/commit/36550692340e4235550f3b9808b5e406821cc979) 中 `FuncOp` 的路径发生了改动。（或许您没有在发布前使用最新版的 llvm-project 仓库进行测试？）
> _This commit moves `FuncOp` out of the builtin dialect, and into the `Func` dialect. ..._
> _This commit handles the functional aspects of the move, but various aspects are left untouched to ease migration: `func::FuncOp` is re-exported into `mlir` to reduce the actual API churn, the assembly format still accepts the unqualified `func`._   --- [D121266](https://reviews.llvm.org/D121266)

2. 修改了 `parseVarDeclaration@Parser.h:445` 中的 instruction。原本的 instruction 中 `eat the variable name` 是不必要的, 因为 identifier 已经被第 464 行的 `eat id` consume 了, 对同学来说可能会是一个比较 confusing 的事情。（如果这是有意的考核可以当我没说）

3. 一些细节上的修改。`parseBlock` 的注释中我推断 `return` 应指代的是 return expression 而非 string literal, 所以去掉了双引号; `parseReturn` 的实现中并没有 eat semicolon 却在注释中写了，根据下文 `parseBlock` 的注释我判断此处应当不需要 eat semicolon，所以选择修改注释使得其与实现保持一致。

4. 另外 `parseIdentifierExpr` 的注释里面或许写成 `::= identifier '(' [(expression,)* expression] ')'` 会更严谨？不过我看 llvm Kaleidoscope tutorial 中也是这么写的，也无伤大雅，所以就没有修改这里

5. ~~一个小 typo: README 中 `test_1` 的执行结果截图中出现了 `identified` 的字样，推测为您 std 出现了 typo~~